### PR TITLE
修复加载默认页面(index.html./index.htm)启用GZIP后http报404问题

### DIFF
--- a/src/wn_module.c
+++ b/src/wn_module.c
@@ -562,7 +562,24 @@ int webnet_module_handle_uri(struct webnet_session *session)
         {
             break;
         }
+#ifdef WEBNET_USING_GZIP
+        if (request->support_gzip)
+        {
+            int len = strlen(full_path);
 
+            if(len + sizeof(".gz") < WEBNET_PATH_MAX)
+            {
+                rt_memcpy(&full_path[len], ".gz", sizeof(".gz"));
+
+                if (stat(full_path, &file_stat) >= 0 && !S_ISDIR(file_stat.st_mode))
+                {
+                    /* remove .gz */
+                    full_path[len] = '\0';
+                    break;
+                }
+            }
+        }
+#endif /* WEBNET_USING_GZIP */
         index ++;
     }
 _end_default_files:


### PR DESCRIPTION
开启webnet的gzip压缩模块，然后将所有页面都压缩为`.gz`文件，但加载默认index页(default_files)时未判断对应的gz文件是否存在，导致浏览器报404错误

```c
/* default index file */
static const char *default_files[] =
{
    "",
    "/index.html",
    "/index.htm",
    RT_NULL
};
```